### PR TITLE
Fixes some errors on Linux system

### DIFF
--- a/PlotsFile-linux.cpp
+++ b/PlotsFile-linux.cpp
@@ -9,7 +9,7 @@ namespace cryo {
 namespace gpuPlotGenerator {
 
 void PlotsFile::preallocate(const std::string& p_path, unsigned long long p_size) throw (std::exception) {
-	int fd = open(p_path.c_str(), O_RDWR | O_CREAT | O_TRUNC);
+	int fd = open(p_path.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0644);
 	if(fd == -1) {
 		throw std::runtime_error("Unable to open the output file");
 	}

--- a/cmake/FindOpenCL.cmake
+++ b/cmake/FindOpenCL.cmake
@@ -122,6 +122,13 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
         lib/x64
         OpenCL/common/lib/x64)
   endif()
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  find_library(OpenCL_LIBRARY
+    NAMES libOpenCL.so
+    PATHS
+        ENV AMDAPPSDKROOT
+    PATH_SUFFIXES
+	lib/x86_64)
 else()
   find_library(OpenCL_LIBRARY
     NAMES OpenCL)


### PR DESCRIPTION
Hi I've encountered some error while doing:
```
$ cmake .
CMake Error at /usr/share/cmake-3.9/Modules/FindPackageHandleStandardArgs.cmake:137 (message):
  Could NOT find OpenCL (missing: OpenCL_LIBRARY) (found version "2.0")
Call Stack (most recent call first):
  /usr/share/cmake-3.9/Modules/FindPackageHandleStandardArgs.cmake:377 (_FPHSA_FAILURE_MESSAGE)
  cmake/FindOpenCL.cmake:143 (find_package_handle_standard_args)
  CMakeLists.txt:7 (find_package)


-- Configuring incomplete, errors occurred!
See also "/home/debian/Build/MINING/orig/gpuPlotGenerator/CMakeFiles/CMakeOutput.log".
See also "/home/debian/Build/MINING/orig/gpuPlotGenerator/CMakeFiles/CMakeError.log".
```

Apparently `if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")` evaluates to "True" when cmake starts finding the OpenCL_LIBRARIES.`


=======

And the other commit fixes the error when `gpuPlotGenerator generate direct` fails to write on the preallocated plot file.

```
./gpuPlotGenerator generate direct 32423423423_0_4096_4096
-------------------------
GPU plot generator v4.1.3
-------------------------
Author:   Cryo
Bitcoin:  138gMBhCrNkbaiTCmUhP9HLU9xwn5QKZgD
Burst:    BURST-YA29-QCEW-QXC3-BKXDL
----
Loading platforms...
Loading devices...
Loading devices configurations...
Initializing generation devices...
    [0] Device: Ellesmere (OpenCL 1.2 AMD-APP (2348.3))
    [0] Device memory: 256MB
    [0] CPU memory: 256MB
Initializing generation contexts...

[ERROR] Unable to open plots file
```
when checking on the file:
```
ls -l 32423423423_0_4096_4096 
---------- 1 user user 1073741824 Aug  3 02:37 32423423423_0_4096_4096
```